### PR TITLE
feat: claim contracts in batches

### DIFF
--- a/fedimint-lnv2-remote-client/src/cli.rs
+++ b/fedimint-lnv2-remote-client/src/cli.rs
@@ -42,8 +42,8 @@ enum Opts {
         #[arg(long)]
         contract_id: sha256::Hash,
     },
-    ClaimContract {
-        claimable_contract_hex: String,
+    ClaimContracts {
+        claimable_contracts_hex: String,
     },
     /// Gateway subcommands
     #[command(subcommand)]
@@ -95,12 +95,12 @@ pub(crate) async fn handle_cli_command(
                 .remove_claimed_contracts(vec![ContractId(contract_id)])
                 .await,
         ),
-        Opts::ClaimContract {
-            claimable_contract_hex,
+        Opts::ClaimContracts {
+            claimable_contracts_hex,
         } => json(
             lightning
-                .claim_contract(
-                    bincode::deserialize(&hex::decode(claimable_contract_hex).unwrap()).unwrap(),
+                .claim_contracts(
+                    bincode::deserialize(&hex::decode(claimable_contracts_hex).unwrap()).unwrap(),
                 )
                 .await?,
         ),


### PR DESCRIPTION
Replace `claim_contract()` with `claim_contracts()`, which allows for batching contract claims into a single fedimint transaction. Beyond optimizing for network bandwidth, this also allows for fewer total ecash note issuances. [Fedimint v0.9.0](https://github.com/fedimint/fedimint/releases/tag/v0.9.0) includes a PR which introduces a fixed cost per ecash input and output (https://github.com/fedimint/fedimint/pull/7725), so allowing for batch contract claiming can save on tx fees.