### PR TITLE
chore: change server type from cx42 to cx43

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           mode: create
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
-          server_type: cx42
+          server_type: cx43
 
   build:
     needs: create-runner


### PR DESCRIPTION
Hetzner deprecated the cx42 and replaced it with the much cheaper cx43 (~55% less costly)

Edit: The CI run on the new cx43 hit a record low time of just over 12 minutes!