### PR TITLE
chore: publish v0.0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-cli"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "fedimint-build",
@@ -3060,7 +3060,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-remote-client"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "aquamarine 0.6.0",
@@ -3089,7 +3089,7 @@ dependencies = [
 
 [[package]]
 name = "fedimint-lnv2-remote-tests"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -3835,7 +3835,7 @@ dependencies = [
 
 [[package]]
 name = "fedimintd"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "fedimint-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["tvolk131"]
 edition = "2024"
 readme = "README.md"
 repository = "https://github.com/tvolk131/fedimint-lnv2-remote-client"
-version = "0.0.6"
+version = "0.0.7"
 
 [workspace.dependencies]
 fedimintd = "0.11.1"


### PR DESCRIPTION
Bumps the workspace crate version to 0.0.7.

Checked with `cargo metadata --locked --no-deps --format-version 1`.